### PR TITLE
Updating the flask version to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.2.2
 numpy==1.21.4
 pandas==1.4.1
 Pillow==9.2.0


### PR DESCRIPTION
Getting error while running older flask version of flask due to dependency and legacy library issues. Updating flask to V2.2.2 will solve that also it is compatible with other libraries mentioned in the requirement.txt